### PR TITLE
Add render_error method

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -46,6 +46,11 @@ module ActionController
       super || _render_in_priorities(options) || " "
     end
 
+    def render_error(*args, &block)
+      options = _normalize_render(*args, &block).with_defaults(status: :unprocessable_entity)
+      render options, &block
+    end
+
     private
       # Before processing, set the request formats in current controller formats.
       def process_action(*) # :nodoc:

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -128,6 +128,14 @@ class TestController < ActionController::Base
     render file: file
   end
 
+  def action_with_error
+    render_error :hello_world
+  end
+
+  def json_with_error
+    render_error json: "hello_world"
+  end
+
   class Collection
     def initialize(records)
       @records = records
@@ -501,6 +509,20 @@ class ExpiresInRenderTest < ActionController::TestCase
   def test_cache_control_no_store_overridden_by_expires_now
     get :cache_control_no_store_overridden_by_expires_now
     assert_equal "no-cache", @response.headers["Cache-Control"]
+  end
+end
+
+class RenderErrorTest < ActionController::TestCase
+  tests TestController
+
+  def test_render_error_with_action
+    get :action_with_error
+    assert_response :unprocessable_entity
+  end
+
+  def test_render_error_with_json
+    get :action_with_error
+    assert_response :unprocessable_entity
   end
 end
 


### PR DESCRIPTION
Adds a `render_error` method to controllers that sets the status. Beginners already have a lot to learn when they start Rails and making sure they use proper error codes can be confusing. This adds a friendly method that sets the status code properly for errors without them having to understand the details. 